### PR TITLE
Python3 compatibility

### DIFF
--- a/octoprint_astroprint/cameramanager/__init__.py
+++ b/octoprint_astroprint/cameramanager/__init__.py
@@ -14,7 +14,7 @@ import warnings
 try:
 	from StringIO import StringIO 
 except ImportError:
-    from io import StringIO
+	from io import StringIO
 
 from threading import Event
 

--- a/octoprint_astroprint/cameramanager/__init__.py
+++ b/octoprint_astroprint/cameramanager/__init__.py
@@ -10,7 +10,12 @@ import requests
 import traceback
 import warnings
 
-from StringIO import StringIO
+## Python2/3 compatibile import
+try:
+	from StringIO import StringIO 
+except ImportError:
+    from io import StringIO
+
 from threading import Event
 
 

--- a/octoprint_astroprint/downloadmanager/__init__.py
+++ b/octoprint_astroprint/downloadmanager/__init__.py
@@ -13,7 +13,7 @@ import os
 try: 
 	from Queue import Queue
 except ImportError:
-	import queue import Queue
+	from queue import Queue
 
 from flask import request
 

--- a/octoprint_astroprint/downloadmanager/__init__.py
+++ b/octoprint_astroprint/downloadmanager/__init__.py
@@ -9,7 +9,11 @@ import requests
 import threading
 import os
 
-from Queue import Queue
+## Python2/3 compatibile import
+try: 
+	from Queue import Queue
+except ImportError:
+	import queue import Queue
 
 from flask import request
 


### PR DESCRIPTION
Fixes issues when running under python 3, as OctoPrint supports it since version `1.4.0`.